### PR TITLE
fix: sets the direction when dragging outside the boundary

### DIFF
--- a/app/game/_components/GameCard.tsx
+++ b/app/game/_components/GameCard.tsx
@@ -33,6 +33,7 @@ type Props = {
   isDragging: boolean;
   isLast: boolean;
   setIsDragOffBoundary: Dispatch<SetStateAction<any>>;
+  setDirection: Dispatch<SetStateAction<any>>;
 };
 
 type cardSwipeDirection = "left" | "right";
@@ -45,6 +46,7 @@ const GameCard = ({
   isDragging,
   isLast,
   setIsDragOffBoundary,
+  setDirection
 }: Props) => {
   const [user, setUser] = useUserContext();
   const { score, previousScore } = user;
@@ -236,14 +238,7 @@ const GameCard = ({
           const direction = info.offset.x > 0 ? "right" : "left";
 
           if (isOffBoundary) {
-            setGame({
-              ...game,
-              cards: game.cards.slice(0, -1),
-            });
-            setUser({
-              score: handleScore({ direction, score, cards }),
-              previousScore: score,
-            });
+            setDirection(direction);
           }
         }}
         style={{ x }}

--- a/app/game/_components/GameCards.tsx
+++ b/app/game/_components/GameCards.tsx
@@ -130,6 +130,7 @@ const GameCards = () => {
                     isDragging={isDragging}
                     isLast={isLast}
                     setIsDragOffBoundary={setIsDragOffBoundary}
+                    setDirection={setDirection}
                   />
                 </motion.div>
               );


### PR DESCRIPTION
When the card is dragged, the exit animation is incorrect, the direction property will be null, so it always exits to the right

![image](https://github.com/lansolo99/tinder-card-game-with-framer-motion/assets/57726726/56de4eed-3782-43b8-a26c-d155ae03d264)

![issue](https://github.com/lansolo99/tinder-card-game-with-framer-motion/assets/57726726/24229c4d-9379-4b92-8cb9-0b1cbab8a809)

My suggestion is to set the direction when it was dragged out, the behavior will be correct, the same way done by the button click

![suggestion](https://github.com/lansolo99/tinder-card-game-with-framer-motion/assets/57726726/2e4f9b7d-86d8-4ae7-9050-3a46f5ac542d)
